### PR TITLE
Add default class to select field

### DIFF
--- a/fSelect.js
+++ b/fSelect.js
@@ -112,6 +112,7 @@
                 }
 
                 this.$wrap.find('.fs-label').html(labelText);
+                this.$wrap.toggleClass('fs-default', labelText === settings.placeholder);
                 this.$select.change();
             }
         }


### PR DESCRIPTION
This adds a default class to the select field if the placeholder is being used. This is useful for styling dropdowns differently if something is selected (i.e. change color)