### PR TITLE
#16 add accented and no accented keywords match

### DIFF
--- a/fSelect.js
+++ b/fSelect.js
@@ -1,6 +1,6 @@
 (function($) {
 
-    String.prototype.unaccented = function(){
+    String.prototype.unaccented = function() {
         var accent = [
             /[\300-\306]/g, /[\340-\346]/g, // A, a
             /[\310-\313]/g, /[\350-\353]/g, // E, e
@@ -13,7 +13,7 @@
         var noaccent = ['A','a','E','e','I','i','O','o','U','u','N','n','C','c'];
 
         var str = this;
-        for(var i = 0; i < accent.length; i++){
+        for (var i = 0; i < accent.length; i++) {
             str = str.replace(accent[i], noaccent[i]);
         }
 
@@ -246,7 +246,7 @@
         if ('' != keywords) {
             $wrap.find('.fs-option').each(function() {
                 var regex = new RegExp(keywords.unaccented(), 'gi');
-                var formatedValue = $(this).find('.fs-option-label').text().unaccented()
+                var formatedValue = $(this).find('.fs-option-label').text().unaccented();
 
                 if (null === formatedValue.match(regex)) {
                     $(this).addClass('hidden');

--- a/fSelect.js
+++ b/fSelect.js
@@ -1,5 +1,25 @@
 (function($) {
 
+    String.prototype.unaccented = function(){
+        var accent = [
+            /[\300-\306]/g, /[\340-\346]/g, // A, a
+            /[\310-\313]/g, /[\350-\353]/g, // E, e
+            /[\314-\317]/g, /[\354-\357]/g, // I, i
+            /[\322-\330]/g, /[\362-\370]/g, // O, o
+            /[\331-\334]/g, /[\371-\374]/g, // U, u
+            /[\321]/g, /[\361]/g, // N, n
+            /[\307]/g, /[\347]/g, // C, c
+        ];
+        var noaccent = ['A','a','E','e','I','i','O','o','U','u','N','n','C','c'];
+
+        var str = this;
+        for(var i = 0; i < accent.length; i++){
+            str = str.replace(accent[i], noaccent[i]);
+        }
+
+        return str;
+    }
+
     $.fn.fSelect = function(options) {
 
         if ('string' === typeof options) {
@@ -225,8 +245,10 @@
 
         if ('' != keywords) {
             $wrap.find('.fs-option').each(function() {
-                var regex = new RegExp(keywords, 'gi');
-                if (null === $(this).find('.fs-option-label').text().match(regex)) {
+                var regex = new RegExp(keywords.unaccented(), 'gi');
+                var formatedValue = $(this).find('.fs-option-label').text().unaccented()
+
+                if (null === formatedValue.match(regex)) {
                     $(this).addClass('hidden');
                 }
             });

--- a/test.html
+++ b/test.html
@@ -2,7 +2,7 @@
 <head>
 <title>fSelect Test</title>
 <link href="fSelect.css" rel="stylesheet">
-<script src="//cdnjs.cloudflare.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
 <script src="fSelect.js"></script>
 <script>
 (function($) {
@@ -15,16 +15,17 @@
 <body>
     <select class="test" multiple="multiple">
         <optgroup label="Group A">
-            <option value="1">Option 1</option>
-            <option value="2" selected>Option 2</option>
-            <option value="3">Option 3</option>
-            <option value="4" disabled>Option 4</option>
-            <option value="5">Option 5</option>
+            <option value="1">Hôpital</option>
+            <option value="2" selected>Noël</option>
+            <option value="3">Île</option>
+            <option value="4" disabled>Manège</option>
+            <option value="5">Bête</option>
         </optgroup>
         <optgroup label="Group B">
             <option value="6" selected>Option 6</option>
             <option value="7">Option 7</option>
             <option value="8">Option 8</option>
+            <option value="9">Mécanique</option>
         </optgroup>
     </select>
 </body>

--- a/test.html
+++ b/test.html
@@ -2,7 +2,7 @@
 <head>
 <title>fSelect Test</title>
 <link href="fSelect.css" rel="stylesheet">
-<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
 <script src="fSelect.js"></script>
 <script>
 (function($) {
@@ -15,9 +15,9 @@
 <body>
     <select class="test" multiple="multiple">
         <optgroup label="Group A">
-            <option value="1">Hôpital</option>
-            <option value="2" selected>Noël</option>
-            <option value="3">Île</option>
+            <option value="1">Option 1</option>
+            <option value="2" selected>Option 2</option>
+            <option value="3">Option 3</option>
             <option value="4" disabled>Manège</option>
             <option value="5">Bête</option>
         </optgroup>


### PR DESCRIPTION
Regarding this issue #16, I replaced all accented characters from the keywords and the options texts to make them match.